### PR TITLE
linebots_controllerのclassが二重になっているのを修正

### DIFF
--- a/app/controllers/linebots_controller.rb
+++ b/app/controllers/linebots_controller.rb
@@ -1,5 +1,4 @@
 class LinebotsController < ApplicationController
-  class LinebotsController < ApplicationController
     require 'line/bot'
   
     # callbackアクションのCSRFトークン認証を無効


### PR DESCRIPTION
class LinebotsController < ApplicationController
が１、２行目に記載されていたため、2行目を削除しました。